### PR TITLE
ENH: Add 52bit data timestamp

### DIFF
--- a/firmware/src/tjmono2_rx/tjmono2_rx.v
+++ b/firmware/src/tjmono2_rx/tjmono2_rx.v
@@ -14,6 +14,7 @@ module tjmono2_rx #(
     parameter   ABUSWIDTH = 16,
     parameter   USE_FIFO_CLK = 0
 ) (
+    input wire TS_CLK,
     input wire FCLK,
     input wire FCLK2X,
     input wire RX_CLKW,
@@ -38,7 +39,7 @@ module tjmono2_rx #(
     input wire          BUS_RD,
     input wire          BUS_WR,
 
-    input wire [26:0]   TIMESTAMP
+    input wire [51:0]   TIMESTAMP
 );
 
 
@@ -83,6 +84,7 @@ tjmono2_rx_core
     .BUS_WR(IP_WR),
     .BUS_DATA_OUT(IP_DATA_OUT),
 
+    .TS_CLK(TS_CLK),
     .FCLK(FCLK),
     .FCLK2X(FCLK2X),
     .RX_CLKW(RX_CLKW),

--- a/firmware/src/tjmono2_rx/tjmono2_rx_core.v
+++ b/firmware/src/tjmono2_rx/tjmono2_rx_core.v
@@ -39,7 +39,6 @@ module tjmono2_rx_core
     input wire BUS_WR,
     input wire BUS_RD,
 
-    input wire CLK40,
     input wire [51:0] TIMESTAMP
 );
 
@@ -204,7 +203,7 @@ assign RX_DATA_DDR = CONF_SAMPLING_EDGE ? Q1 : Q2;
 wire cdc_fifo_empty, cdc_fifo_full;
 wire RESET_FIFO, RESET_WCLK;
 wire [51:0] TIMESTAMP_WCLK; // Timestamp in FCLK domain
-cdc_reset_sync rst_wclk_sync (.clk_in(BUS_CLK), .pulse_in(RST), .clk_out(CLK40), .pulse_out(RESET_WCLK));
+cdc_reset_sync rst_wclk_sync (.clk_in(BUS_CLK), .pulse_in(RST), .clk_out(TS_CLK), .pulse_out(RESET_WCLK));
 cdc_reset_sync rst_fclk_sync (.clk_in(BUS_CLK), .pulse_in(RST), .clk_out(RX_CLKW), .pulse_out(RESET_FIFO));
 
 // Continuously put timestamp in very short fifo for constant overwrite if not read
@@ -217,7 +216,7 @@ cdc_syncfifo #(
     .rempty(cdc_fifo_empty),
     .wdata(TIMESTAMP),
     .winc(1'b1),
-    .wclk(CLK40),
+    .wclk(TS_CLK),
     .wrst(RESET_WCLK),
     .rinc(!cdc_fifo_empty),
     .rclk(RX_CLKW),

--- a/firmware/src/tjmono2_rx/tjmono2_rx_core.v
+++ b/firmware/src/tjmono2_rx/tjmono2_rx_core.v
@@ -13,6 +13,7 @@ module tjmono2_rx_core
     parameter           ABUSWIDTH = 32
 )
 (
+    input wire TS_CLK,
     input wire FCLK,
     input wire FCLK2X,
     input wire RX_CLKW,
@@ -38,7 +39,7 @@ module tjmono2_rx_core
     input wire BUS_WR,
     input wire BUS_RD,
 
-    input wire [26:0] TIMESTAMP
+    input wire [51:0] TIMESTAMP
 );
 
 localparam VERSION = 1;
@@ -198,6 +199,30 @@ IDDR IDDR_RX (
 wire RX_DATA_DDR;
 assign RX_DATA_DDR = CONF_SAMPLING_EDGE ? Q1 : Q2;
 
+// Resample timestamp to RX_CLKW domain
+wire cdc_fifo_empty, cdc_fifo_full;
+wire RESET_FIFO, RESET_WCLK;
+wire [51:0] TIMESTAMP_WCLK; // Timestamp in FCLK domain
+cdc_reset_sync rst_wclk_sync (.clk_in(BUS_CLK), .pulse_in(RST), .clk_out(CLK40), .pulse_out(RESET_WCLK));
+cdc_reset_sync rst_fclk_sync (.clk_in(BUS_CLK), .pulse_in(RST), .clk_out(RX_CLKW), .pulse_out(RESET_FIFO));
+
+// Continuously put timestamp in very short fifo for constant overwrite if not read
+cdc_syncfifo #(
+    .DSIZE(52),
+    .ASIZE(2)
+) cdc_syncfifo_i (
+    .rdata(TIMESTAMP_WCLK),
+    .wfull(cdc_fifo_full),
+    .rempty(cdc_fifo_empty),
+    .wdata(TIMESTAMP),
+    .winc(1'b1),
+    .wclk(CLK40),
+    .wrst(RESET_WCLK),
+    .rinc(!cdc_fifo_empty),
+    .rclk(RX_CLKW),
+    .rrst(RESET_FIFO)
+);
+
 receiver_logic receiver_logic 
 (
     .RESET(RST),
@@ -222,7 +247,7 @@ receiver_logic receiver_logic
     .load_rawcnt(CONF_LOAD_RAWCNT),
     .empty_record(CONF_EMPTY_RECORD),
     .FIFO_CLK(FIFO_CLK),
-    .TIMESTAMP(TIMESTAMP)
+    .TIMESTAMP(TIMESTAMP_WCLK)
 );
 
 endmodule

--- a/firmware/src/tjmono2_rx/tjmono2_rx_core.v
+++ b/firmware/src/tjmono2_rx/tjmono2_rx_core.v
@@ -39,6 +39,7 @@ module tjmono2_rx_core
     input wire BUS_WR,
     input wire BUS_RD,
 
+    input wire CLK40,
     input wire [51:0] TIMESTAMP
 );
 

--- a/firmware/src/tjmonopix2_core.v
+++ b/firmware/src/tjmonopix2_core.v
@@ -553,7 +553,8 @@ tlu_controller #(
     .DIVISOR(8),
     .ABUSWIDTH(ABUSWIDTH),
     .WIDTH(8),
-    .TLU_TRIGGER_MAX_CLOCK_CYCLES(32)
+    .TLU_TRIGGER_MAX_CLOCK_CYCLES(32),
+    .TIMESTAMP_N_OF_BIT(64)
 ) i_tlu_controller (
     .BUS_CLK(BUS_CLK),
     .BUS_RST(BUS_RST),
@@ -654,24 +655,6 @@ tdc_s3 #(
     .TIMESTAMP(TIMESTAMP[15:0])
 );
 
-// sync TIMESTAMP from CLK40 to CLK16
-wire [26:0] timestep_gray;
-bin2gray bin2gray (.bin(TIMESTAMP), .gray(timestep_gray));
-reg [26:0] timestep_gray_sync;
-
-always@(posedge CLK40)
-    timestep_gray_sync <= timestep_gray;
-
-reg [26:0] timestep_gray_16_0, timestep_gray_16;
-
-always@(posedge CLK16) begin
-    timestep_gray_16_0 <= timestep_gray_sync;
-    timestep_gray_16 <= timestep_gray_16_0;
-end
-
-wire [26:0] TIMESTAMP16;
-gray2bin gray2bin ( .gray(timestep_gray_16), .bin(TIMESTAMP16));
-
 // fast readout
 tjmono2_rx #(
     .BASEADDR(RX_BASEADDR),
@@ -680,6 +663,7 @@ tjmono2_rx #(
     .ABUSWIDTH(ABUSWIDTH),
     .USE_FIFO_CLK(0)
 ) tjmono2_rx (
+    .TS_CLK(CLK40),
     .FCLK(CLK160),
     .FCLK2X(CLK320),
     .RX_CLKW(CLK16),
@@ -697,7 +681,7 @@ tjmono2_rx #(
     .RX_FIFO_FULL(),
     .RX_ENABLED(),
 
-    .TIMESTAMP(TIMESTAMP16),
+    .TIMESTAMP(TIMESTAMP[51:0]),
 
     .BUS_CLK(BUS_CLK),
     .BUS_RST(BUS_RST),


### PR DESCRIPTION
This PR increases the number of bits with which the incoming frames get timestamped to prevent continuous overflow. At 40 MHz the timestamp will overflow after thousands of hours. This helps with event building.
An additional raw data word for the added bits is introduced with these changes.