### PR TITLE
Trigger data format

### DIFF
--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -51,6 +51,7 @@ class Analysis(object):
             self.run_config = au.ConfigDict(in_file.root.configuration_in.scan.run_config[:])
             self.scan_config = au.ConfigDict(in_file.root.configuration_in.scan.scan_config[:])
             self.chip_settings = au.ConfigDict(in_file.root.configuration_in.chip.settings[:])
+            self.tlu_config = au.ConfigDict(in_file.root.configuration_in.bench.TLU[:])
 
     def __enter__(self):
         return self
@@ -151,7 +152,7 @@ class Analysis(object):
                 if self.store_hits:
                     hit_table = self._create_hit_table(out_file, dtype=au.hit_dtype)
 
-                interpreter = RawDataInterpreter(n_scan_params=n_scan_params)
+                interpreter = RawDataInterpreter(n_scan_params=n_scan_params, trigger_data_format=self.tlu_config['DATA_FORMAT'])
                 self.last_chunk = False
                 pbar = tqdm(total=n_words, unit=' Words', unit_scale=True)
                 upd = 0

--- a/tjmonopix2/analysis/interpreter.py
+++ b/tjmonopix2/analysis/interpreter.py
@@ -39,16 +39,6 @@ def is_tdc(word):
 
 
 @numba.njit
-def get_tlu_number(word):
-    return word & 0xFFFF
-
-
-@numba.njit
-def get_tlu_timestamp(word):
-    return (word >> 16) & 0x7FFF
-
-
-@numba.njit
 def is_tjmono_timestamp_msb(word):
     return (word & 0xFC000000) == 0x4C000000
 

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -23,7 +23,6 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib import colors, cm
 from matplotlib.backends.backend_pdf import PdfPages
-import matplotlib.ticker as ticker
 
 from tjmonopix2.system import logger
 from tjmonopix2.analysis import analysis_utils as au


### PR DESCRIPTION
This PR adds functionality to interpret all available `TRIGGER_DATA_FORMAT` formats of the [TLU module](https://github.com/SiLab-Bonn/basil/tree/master/basil/firmware/modules/tlu). Interpretation format is based on the format specified in `testbench.yaml`