### PR TITLE
ENH: Enable clustering for simple scan data

### DIFF
--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -303,7 +303,7 @@ class Analysis(object):
                                            complevel=5,
                                            fletcher32=False))
                     hist_cs_size = np.zeros(shape=(30, ), dtype=np.uint32)
-                    hist_cs_tot = np.zeros(shape=(128, ), dtype=np.uint32)
+                    hist_cs_tot = np.zeros(shape=(256, ), dtype=np.uint32)
                     hist_cs_shape = np.zeros(shape=(300, ), dtype=np.int32)
 
                 interpreter = RawDataInterpreter(n_scan_params=n_scan_params, trigger_data_format=self.tlu_config['DATA_FORMAT'])
@@ -350,7 +350,7 @@ class Analysis(object):
                         cluster_table.append(cluster)
                         # Create actual cluster hists
                         cs_size = np.bincount(cluster['size'], minlength=30)[:30]
-                        cs_tot = np.bincount(cluster['tot'], minlength=128)[:128]
+                        cs_tot = np.bincount(cluster['tot'], minlength=256)[:256]
                         sel = np.logical_and(cluster['cluster_shape'] > 0, cluster['cluster_shape'] < 300)
                         cs_shape = np.bincount(cluster['cluster_shape'][sel], minlength=300)[:300]
                         # Add to total hists

--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -349,14 +349,10 @@ class Analysis(object):
                         _, cluster = self.clz.cluster_hits(data_to_clusterizer)
                         cluster_table.append(cluster)
                         # Create actual cluster hists
-                        cs_size = np.bincount(cluster['size'],
-                                                minlength=30)[:30]
-                        cs_tot = np.bincount(cluster['tot'],
-                                                minlength=128)[:128]
-                        sel = np.logical_and(cluster['cluster_shape'] > 0,
-                                                cluster['cluster_shape'] < 300)
-                        cs_shape = np.bincount(cluster['cluster_shape'][sel],
-                                                minlength=300)[:300]
+                        cs_size = np.bincount(cluster['size'], minlength=30)[:30]
+                        cs_tot = np.bincount(cluster['tot'], minlength=128)[:128]
+                        sel = np.logical_and(cluster['cluster_shape'] > 0, cluster['cluster_shape'] < 300)
+                        cs_shape = np.bincount(cluster['cluster_shape'][sel], minlength=300)[:300]
                         # Add to total hists
                         hist_cs_size += cs_size.astype(np.uint32)
                         hist_cs_tot += cs_tot.astype(np.uint32)

--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -33,6 +33,9 @@ class Analysis(object):
         self.analyze_tdc = analyze_tdc
         self.use_tdc_trigger_dist = use_tdc_trigger_dist
 
+        if self.build_events:
+            self.cluster_hits = True
+
         if not os.path.isfile(raw_data_file):
             raise IOError('Raw data file %s does not exist.', raw_data_file)
 
@@ -299,8 +302,8 @@ class Analysis(object):
                         filters=tb.Filters(complib='blosc',
                                            complevel=5,
                                            fletcher32=False))
-                    hist_cs_size = np.zeros(shape=(100, ), dtype=np.uint32)
-                    hist_cs_tot = np.zeros(shape=(100, ), dtype=np.uint32)
+                    hist_cs_size = np.zeros(shape=(30, ), dtype=np.uint32)
+                    hist_cs_tot = np.zeros(shape=(128, ), dtype=np.uint32)
                     hist_cs_shape = np.zeros(shape=(300, ), dtype=np.int32)
 
                 interpreter = RawDataInterpreter(n_scan_params=n_scan_params, trigger_data_format=self.tlu_config['DATA_FORMAT'])
@@ -329,28 +332,43 @@ class Analysis(object):
                         else:
                             self.log.error("No TLU data found in raw data. Check data or disable event building")
                             raise Exception
-                        if self.cluster_hits:  # FIXME Currently only supported for event data
-                            _, cluster = self.clz.cluster_hits(event_dat)
-                            cluster_table.append(cluster)
-                            # Create actual cluster hists
-                            cs_size = np.bincount(cluster['size'],
-                                                  minlength=100)[:100]
-                            cs_tot = np.bincount(cluster['tot'],
-                                                 minlength=100)[:100]
-                            sel = np.logical_and(cluster['cluster_shape'] > 0,
-                                                 cluster['cluster_shape'] < 300)
-                            cs_shape = np.bincount(cluster['cluster_shape'][sel],
-                                                   minlength=300)[:300]
-                            # Add to total hists
-                            hist_cs_size += cs_size.astype(np.uint32)
-                            hist_cs_tot += cs_tot.astype(np.uint32)
-                            hist_cs_shape += cs_shape.astype(np.uint32)
+                    if self.cluster_hits:
+                        if self.build_events:
+                            data_to_clusterizer = event_dat
+                        else:
+                            hit_data_cs_fmt = np.zeros(len(hit_dat), dtype=au.event_dtype)
+                            hit_data_cs_fmt['event_number'][:] = hit_dat['timestamp'][:]
+                            hit_data_cs_fmt['trigger_number'][:] = -1
+                            hit_data_cs_fmt['frame'][:] = -1
+                            hit_data_cs_fmt['column'][:] = hit_dat['col'][:]
+                            hit_data_cs_fmt['row'][:] = hit_dat['row'][:]
+                            hit_data_cs_fmt['charge'][:] = ((hit_dat[:]["te"] - hit_dat[:]["le"]) & 0x7F) + 1
+                            hit_data_cs_fmt['timestamp'][:] = hit_dat['timestamp'][:]
+                            data_to_clusterizer = hit_data_cs_fmt
+
+                        _, cluster = self.clz.cluster_hits(data_to_clusterizer)
+                        cluster_table.append(cluster)
+                        # Create actual cluster hists
+                        cs_size = np.bincount(cluster['size'],
+                                                minlength=30)[:30]
+                        cs_tot = np.bincount(cluster['tot'],
+                                                minlength=128)[:128]
+                        sel = np.logical_and(cluster['cluster_shape'] > 0,
+                                                cluster['cluster_shape'] < 300)
+                        cs_shape = np.bincount(cluster['cluster_shape'][sel],
+                                                minlength=300)[:300]
+                        # Add to total hists
+                        hist_cs_size += cs_size.astype(np.uint32)
+                        hist_cs_tot += cs_tot.astype(np.uint32)
+                        hist_cs_shape += cs_shape.astype(np.uint32)
                     pbar.update(upd)
                 pbar.close()
 
                 hist_occ, hist_tot, hist_tdc = interpreter.get_histograms()
 
         self._create_additional_hit_data(hist_occ, hist_tot)
+        if self.cluster_hits:
+            self._create_additional_cluster_data(hist_cs_size, hist_cs_tot, hist_cs_shape)
 
     def _create_additional_hit_data(self, hist_occ, hist_tot):
         with tb.open_file(self.analyzed_data_file, 'r+') as out_file:
@@ -398,3 +416,30 @@ class Analysis(object):
                                        filters=tb.Filters(complib='blosc', complevel=5, fletcher32=False))
                 out_file.create_carray(out_file.root, name='Chi2Map', title='Chi2 / ndf Map', obj=self.chi2_map,
                                        filters=tb.Filters(complib='blosc', complevel=5, fletcher32=False))
+
+    def _create_additional_cluster_data(self, hist_cs_size, hist_cs_tot, hist_cs_shape):
+        '''
+            Store cluster histograms in analyzed data file
+        '''
+        with tb.open_file(self.analyzed_data_file, 'r+') as out_file:
+            out_file.create_carray(out_file.root,
+                                   name='HistClusterSize',
+                                   title='Cluster Size Histogram',
+                                   obj=hist_cs_size,
+                                   filters=tb.Filters(complib='blosc',
+                                                      complevel=5,
+                                                      fletcher32=False))
+            out_file.create_carray(out_file.root,
+                                   name='HistClusterTot',
+                                   title='Cluster ToT Histogram',
+                                   obj=hist_cs_tot,
+                                   filters=tb.Filters(complib='blosc',
+                                                      complevel=5,
+                                                      fletcher32=False))
+            out_file.create_carray(out_file.root,
+                                   name='HistClusterShape',
+                                   title='Cluster Shape Histogram',
+                                   obj=hist_cs_shape,
+                                   filters=tb.Filters(complib='blosc',
+                                                      complevel=5,
+                                                      fletcher32=False))

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -131,7 +131,7 @@ class Plotting(object):
             self.log.warning('Disabled {} noisy pixels in total.'.format(len(noisy_pixels[0])))
 
         try:
-            self.Cluster = root.Cluster[:]  # FIXME: This line of code does not take chunking into account
+            _ = root.Cluster[:]  # FIXME: This line of code does not take chunking into account
             self.HistClusterSize = root.HistClusterSize[:]
             self.HistClusterShape = root.HistClusterShape[:]
             self.HistClusterTot = root.HistClusterTot[:]

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -164,10 +164,9 @@ class Plotting(object):
         else:
             self.create_parameter_page()
             self.create_occupancy_map()
-            if self.run_config['scan_id'] in ['source_scan']:
+            if self.run_config['scan_id'] in ['simple_scan']:
                 self.create_fancy_occupancy()
-                self.create_tot_plot()
-            if self.run_config['scan_id'] in ['analog_scan', 'threshold_scan', 'global_threshold_tuning', 'source_scan']:
+            if self.run_config['scan_id'] in ['analog_scan', 'threshold_scan', 'global_threshold_tuning', 'simple_scan']:
                 self.create_hit_pix_plot()
                 self.create_tdac_plot()
                 self.create_tdac_map()
@@ -216,13 +215,19 @@ class Plotting(object):
         except Exception:
             self.log.error('Could not create occupancy map!')
 
+    def create_fancy_occupancy(self):
+        try:
+            self._plot_fancy_occupancy(hist=np.ma.masked_array(self.HistOcc[:].sum(axis=2), self.enable_mask).T)
+        except Exception:
+            self.log.error('Could not create fancy occupancy plot!')
+
     def create_tot_plot(self):
         ''' Create 1D tot plot '''
         try:
             title = ('Time-over-Threshold distribution ($\\Sigma$ = {0:1.0f})'.format(np.sum(self.HistTot.sum(axis=(0, 1, 2)).T)))
             self._plot_1d_hist(hist=self.HistTot.sum(axis=(0, 1, 2)).T,
                                title=title,
-                               log_y=True,
+                               log_y=False,
                                plot_range=range(0, self.HistTot.shape[3]),
                                x_axis_title='ToT code',
                                y_axis_title='# of hits',

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -42,7 +42,7 @@ DACS = {'TJMONOPIX2': ['IBIAS', 'ITHR',
 
 
 class Plotting(object):
-    def __init__(self, analyzed_data_file, pdf_file=None, level='preliminary', mask_noisy_pixels=False, clustered=False, internal=False, save_single_pdf=False, save_png=False):
+    def __init__(self, analyzed_data_file, pdf_file=None, level='preliminary', mask_noisy_pixels=False, internal=False, save_single_pdf=False, save_png=False):
         self.log = logger.setup_derived_logger('Plotting')
 
         self.plot_cnt = 0
@@ -51,7 +51,7 @@ class Plotting(object):
         self.level = level
         self.mask_noisy_pixels = mask_noisy_pixels
         self.internal = internal
-        self.clustered = clustered
+        self.clustered = False
         self.skip_plotting = False
         self.cb_side = False
         self._module_type = None
@@ -474,8 +474,13 @@ class Plotting(object):
     def create_cluster_tot_plot(self):
         ''' Create 1D cluster ToT plot '''
         try:
+            if np.max(np.nonzero(self.HistClusterTot)) < 128:
+                plot_range = range(0, 128)
+            else:
+                plot_range = range(0, np.max(np.nonzero(self.HistClusterTot)))
+
             self._plot_1d_hist(hist=self.HistClusterTot[:], title='Cluster ToT',
-                               log_y=False, plot_range=range(0, 128),
+                               log_y=False, plot_range=plot_range,
                                x_axis_title='Cluster ToT [25 ns]',
                                y_axis_title='# of clusters', suffix='cluster_tot')
         except Exception:

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -460,9 +460,9 @@ class Plotting(object):
         ''' Create 1D cluster size plot '''
         try:
             self._plot_1d_hist(hist=self.HistClusterSize[:], title='Cluster size',
-                            log_y=False, plot_range=range(0, 10),
-                            x_axis_title='Cluster size',
-                            y_axis_title='# of clusters', suffix='cluster_size')
+                               log_y=False, plot_range=range(0, 10),
+                               x_axis_title='Cluster size',
+                               y_axis_title='# of clusters', suffix='cluster_size')
         except Exception:
             self.log.error('Could not create cluster size plot!')
 
@@ -470,9 +470,9 @@ class Plotting(object):
         ''' Create 1D cluster ToT plot '''
         try:
             self._plot_1d_hist(hist=self.HistClusterTot[:], title='Cluster ToT',
-                            log_y=False, plot_range=range(0, 128),
-                            x_axis_title='Cluster ToT [25 ns]',
-                            y_axis_title='# of clusters', suffix='cluster_tot')
+                               log_y=False, plot_range=range(0, 128),
+                               x_axis_title='Cluster ToT [25 ns]',
+                               y_axis_title='# of clusters', suffix='cluster_tot')
         except Exception:
             self.log.error('Could not create cluster TOT plot!')
 

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -42,7 +42,7 @@ DACS = {'TJMONOPIX2': ['IBIAS', 'ITHR',
 
 
 class Plotting(object):
-    def __init__(self, analyzed_data_file, pdf_file=None, level='preliminary', mask_noisy_pixels=False, internal=False, save_single_pdf=False, save_png=False):
+    def __init__(self, analyzed_data_file, pdf_file=None, level='preliminary', mask_noisy_pixels=False, clustered=False, internal=False, save_single_pdf=False, save_png=False):
         self.log = logger.setup_derived_logger('Plotting')
 
         self.plot_cnt = 0
@@ -51,7 +51,7 @@ class Plotting(object):
         self.level = level
         self.mask_noisy_pixels = mask_noisy_pixels
         self.internal = internal
-        self.clustered = False
+        self.clustered = clustered
         self.skip_plotting = False
         self.cb_side = False
         self._module_type = None
@@ -455,6 +455,32 @@ class Plotting(object):
                                  suffix='chi2_map')
         except Exception:
             self.log.error('Could not create chi2 map!')
+
+    def create_cluster_size_plot(self):
+        ''' Create 1D cluster size plot '''
+        try:
+            self._plot_1d_hist(hist=self.HistClusterSize[:], title='Cluster size',
+                            log_y=False, plot_range=range(0, 10),
+                            x_axis_title='Cluster size',
+                            y_axis_title='# of clusters', suffix='cluster_size')
+        except Exception:
+            self.log.error('Could not create cluster size plot!')
+
+    def create_cluster_tot_plot(self):
+        ''' Create 1D cluster ToT plot '''
+        try:
+            self._plot_1d_hist(hist=self.HistClusterTot[:], title='Cluster ToT',
+                            log_y=False, plot_range=range(0, 128),
+                            x_axis_title='Cluster ToT [25 ns]',
+                            y_axis_title='# of clusters', suffix='cluster_tot')
+        except Exception:
+            self.log.error('Could not create cluster TOT plot!')
+
+    def create_cluster_shape_plot(self):
+        try:
+            self._plot_cl_shape(self.HistClusterShape[:])
+        except Exception:
+            self.log.error('Could not create cluster shape plot!')
 
     def create_hit_pix_plot(self):
         try:
@@ -1133,3 +1159,41 @@ class Plotting(object):
         ax.grid(True)
 
         self._save_plots(fig, suffix=suffix)
+
+    def _plot_cl_shape(self, hist):
+        ''' Create a histogram with selected cluster shapes '''
+        x = np.arange(12)
+        fig = Figure()
+        _ = FigureCanvas(fig)
+        ax = fig.add_subplot(111)
+        self._add_text(fig)
+
+        selected_clusters = hist[[1, 3, 5, 6, 9, 13, 14, 7, 11, 19, 261, 15]]
+        ax.bar(x, selected_clusters, align='center')
+        ax.xaxis.set_ticks(x)
+        fig.subplots_adjust(bottom=0.2)
+        ax.set_xticklabels(["\u2004\u2596",
+                            # 2 hit cluster, horizontal
+                            "\u2597\u2009\u2596",
+                            # 2 hit cluster, vertical
+                            "\u2004\u2596\n\u2004\u2598",
+                            "\u259e",  # 2 hit cluster
+                            "\u259a",  # 2 hit cluster
+                            "\u2599",  # 3 hit cluster, L
+                            "\u259f",  # 3 hit cluster
+                            "\u259b",  # 3 hit cluster
+                            "\u259c",  # 3 hit cluster
+                            # 3 hit cluster, horizontal
+                            "\u2004\u2596\u2596\u2596",
+                            # 3 hit cluster, vertical
+                            "\u2004\u2596\n\u2004\u2596\n\u2004\u2596",
+                            # 4 hit cluster
+                            "\u2597\u2009\u2596\n\u259d\u2009\u2598"])
+        ax.set_title('Cluster shapes', color=TITLE_COLOR)
+        ax.set_xlabel('Cluster shape')
+        ax.set_ylabel('# of clusters')
+        ax.grid(True)
+        ax.set_yscale('log')
+        ax.set_ylim(ymin=1e-1)
+
+        self._save_plots(fig, suffix='cluster_shape')


### PR DESCRIPTION
This PR enables the option to run cluster analysis for regular source measurements and data after event building (e.g. TB data). Plotting of the clustered data is also added. 