### PR TITLE
ToT calibration script on per pixel level

### DIFF
--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -394,11 +394,11 @@ class Analysis(object):
             #                                               complevel=5,
             #                                               fletcher32=False))
 
-            if scan_id in ['threshold_scan']:
+            if scan_id in ['threshold_scan', 'calibrate_tot']:
                 n_injections = self.scan_config['n_injections']
                 hist_scurve = hist_occ.reshape((self.rows * self.columns, -1))
 
-                if scan_id in ['threshold_scan']:
+                if scan_id in ['threshold_scan', 'calibrate_tot']:
                     scan_params = [self.scan_config['VCAL_HIGH'] - v for v in range(self.scan_config['VCAL_LOW_start'],
                                                                                     self.scan_config['VCAL_LOW_stop'], self.scan_config['VCAL_LOW_step'])]
                     self.threshold_map, self.noise_map, self.chi2_map = au.fit_scurves_multithread(hist_scurve, scan_params, n_injections, optimize_fit_range=False)

--- a/tjmonopix2/analysis/analysis_utils.py
+++ b/tjmonopix2/analysis/analysis_utils.py
@@ -35,7 +35,7 @@ event_dtype = np.dtype([
     ("frame", "<u1"),
     ("column", "<u2"),
     ("row", "<u2"),
-    ("charge", "<u1"),
+    ("charge", "<u2"),
     ("timestamp", "<i8"),
 ])
 
@@ -80,6 +80,11 @@ class ConfigDict(dict):
 
 def _fit_func(x, a, b, d):
     return (a / x + 1 / b) * (x - d)
+
+
+@numba.njit
+def _inv_fit_func(tot, a, b ,d):
+    return (np.sqrt(b**2 * (a - tot)**2 + 2 * b * d * (a + tot) + d**2) - b * a + b * tot + d) * 0.5
 
 
 def scurve(x, A, mu, sigma):

--- a/tjmonopix2/analysis/analysis_utils.py
+++ b/tjmonopix2/analysis/analysis_utils.py
@@ -78,12 +78,12 @@ class ConfigDict(dict):
             return key, val
 
 
-def _fit_func(x, a, b, d):
+def _tot_response_func(x, a, b, d):
     return (a / x + 1 / b) * (x - d)
 
 
 @numba.njit
-def _inv_fit_func(tot, a, b, d):
+def _inv_tot_response_func(tot, a, b, d):
     return (np.sqrt(b**2 * (a - tot)**2 + 2 * b * d * (a + tot) + d**2) - b * a + b * tot + d) * 0.5
 
 
@@ -435,12 +435,12 @@ def fit_scurves_multithread(scurves, scan_params, n_injections=None, invert_x=Fa
     return thr2D, sig2D, chi2ndf2D
 
 
-def fit_tot_inj_multithread(tot_avg, scan_params):
+def fit_tot_response_multithread(tot_avg, scan_params):
 
     scurves_masked = np.ma.masked_array(tot_avg)
 
     logger.info("Start injection ToT calibration fit on %d CPU core(s)", mp.cpu_count())
-    partialfit_tot_inj_func = partial(_fit_tot_inj, scan_params=scan_params)
+    partialfit_tot_inj_func = partial(_fit_tot_response, scan_params=scan_params)
 
     result_list = imap_bar(partialfit_tot_inj_func, scurves_masked.tolist(), unit=' Fits', unit_scale=True)  # Masked array entries to list leads to NaNs
     result_array = np.array(result_list)
@@ -448,7 +448,7 @@ def fit_tot_inj_multithread(tot_avg, scan_params):
     return np.reshape(result_array, (512, 512, 4))
 
 
-def _fit_tot_inj(data, scan_params):
+def _fit_tot_response(data, scan_params):
     '''
         Fit one pixel data with injection Tot calibration function.
         Has to be global function for the multiprocessing module.
@@ -476,10 +476,10 @@ def _fit_tot_inj(data, scan_params):
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", OptimizeWarning)
-            popt = curve_fit(f=lambda x, a, b, d: _fit_func(x, a, b, d),
+            popt = curve_fit(f=lambda x, a, b, d: _tot_response_func(x, a, b, d),
                              xdata=x[y > 0], ydata=y[y > 0], p0=p0, sigma=yerr[y > 0],
                              absolute_sigma=True)[0]
-            chi2 = np.sum((y - _fit_func(x, *popt)) ** 2)
+            chi2 = np.sum((y - _tot_response_func(x, *popt)) ** 2)
     except RuntimeError:  # fit failed
         return (0., 0., 0., 0.)
 

--- a/tjmonopix2/analysis/analysis_utils.py
+++ b/tjmonopix2/analysis/analysis_utils.py
@@ -83,7 +83,7 @@ def _fit_func(x, a, b, d):
 
 
 @numba.njit
-def _inv_fit_func(tot, a, b ,d):
+def _inv_fit_func(tot, a, b, d):
     return (np.sqrt(b**2 * (a - tot)**2 + 2 * b * d * (a + tot) + d**2) - b * a + b * tot + d) * 0.5
 
 

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -137,7 +137,7 @@ class Plotting(object):
             self.HistClusterTot = root.HistClusterTot[:]
             self.clustered = True
             conversion_factors = au.ConfigDict(root.configuration_in.bench.calibration['electron_conversion'])
-            if np.any(self.enable_mask[0:448, :]):  # TODO: Get rid of hardcoded values.
+            if self.scan_config['start_column'] in range(0, 448):  # TODO: Get rid of hardcoded values.
                 self.electron_conversion = conversion_factors['DC_coupled']
             else:
                 self.electron_conversion = conversion_factors['AC_coupled']

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -267,7 +267,7 @@ class Plotting(object):
                 scan_parameter_range = self.scan_parameter_range
             else:
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = False  # TODO: True after calibration code is done
+                electron_axis = True
                 scan_parameter_range = self.scan_parameter_range
 
             params = [{'scurves': self.HistOcc[:].ravel().reshape((self.rows * self.cols, -1)).T,
@@ -295,7 +295,7 @@ class Plotting(object):
             else:
                 plot_range = self.scan_parameter_range
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = False  # TODO: True after calibration code is done
+                electron_axis = True
 
             self._plot_distribution(self.ThresholdMap[self.Chi2Sel].T,
                                     plot_range=plot_range,
@@ -319,7 +319,7 @@ class Plotting(object):
                 electron_axis = False
             else:
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = False  # TODO: True after calibration code is done
+                electron_axis = True
 
             self._plot_stacked_threshold(data=self.ThresholdMap[self.Chi2Sel].T,
                                          tdac_mask=self.tdac_mask[self.Chi2Sel].T,
@@ -348,8 +348,8 @@ class Plotting(object):
                 z_min = 0
                 z_max = 16
             else:
-                electron_axis = False  # TODO: True after calibration code is done
-                use_electron_offset = False  # TODO: True after calibration code is done
+                electron_axis = True
+                use_electron_offset = False
                 z_label = 'Threshold'
                 title = 'Threshold'
                 z_min = None
@@ -376,7 +376,7 @@ class Plotting(object):
             plot_range = None
             if self.run_config['scan_id'] in ['threshold_scan', 'fast_threshold_scan', 'in_time_threshold_scan', 'autorange_threshold_scan', 'crosstalk_scan']:
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = False  # TODO: True after calibration code is done
+                electron_axis = True
             elif self.run_config['scan_id'] == 'global_threshold_tuning':
                 scan_parameter_name = self.scan_config['VTH_name']
                 electron_axis = False
@@ -404,7 +404,7 @@ class Plotting(object):
             mask[~sel] = True
             z_label = 'Noise'
             title = 'Noise'
-            electron_axis = False  # TODO: True after calibration code is done
+            electron_axis = True
 
             if self.run_config['scan_id'] == 'injection_delay_scan':
                 z_label = 'Finedelay [LSB]'
@@ -562,16 +562,16 @@ class Plotting(object):
         if self.internal:
             fig.text(0.1, 1, 'Internal', fontsize=16, color='r', rotation=45, bbox=dict(boxstyle='round', facecolor='white', edgecolor='red', alpha=0.7), transform=fig.transFigure)
 
-    def _convert_to_e(self, dac, use_offset=True):
+    def _convert_to_e(self, dac, use_offset=False):
         if use_offset:
             e = dac * self.calibration['e_conversion_slope'] + self.calibration['e_conversion_offset']
             de = math.sqrt((dac * self.calibration['e_conversion_slope_error'])**2 + self.calibration['e_conversion_offset_error']**2)
         else:
-            e = dac * self.calibration['e_conversion_slope']
-            de = dac * self.calibration['e_conversion_slope_error']
+            e = dac * self.electron_conversion
+            de = dac * self.electron_conversion * 0.15  # TODO: Replace generic 15% error of conversion factor
         return e, de
 
-    def _add_electron_axis(self, fig, ax, use_electron_offset=True):
+    def _add_electron_axis(self, fig, ax, use_electron_offset=False):
         fig.subplots_adjust(top=0.75)
         ax.title.set_position([.5, 1.15])
 

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -136,6 +136,11 @@ class Plotting(object):
             self.HistClusterShape = root.HistClusterShape[:]
             self.HistClusterTot = root.HistClusterTot[:]
             self.clustered = True
+            conversion_factors = au.ConfigDict(root.configuration_in.bench.calibration['electron_conversion'])
+            if np.any(self.enable_mask[0:448, :]):  # TODO: Get rid of hardcoded values.
+                self.electron_conversion = conversion_factors['DC_coupled']
+            else:
+                self.electron_conversion = conversion_factors['AC_coupled']
         except tb.NoSuchNodeError:
             pass
 
@@ -481,11 +486,13 @@ class Plotting(object):
 
             tot_calib_file = self.configuration['scan'].get('tot_calib_file', None)
             if tot_calib_file is not None:
-                x_axis_title = 'Electrons [e⁻]'
+                x_axis_title = 'Cluster Charge [e⁻]'
+                hist = self.HistClusterTot[:] * self.electron_conversion
             else:
                 x_axis_title = 'Cluster ToT [25 ns]'
+                hist = self.HistClusterTot[:]
 
-            self._plot_1d_hist(hist=self.HistClusterTot[:], title='Cluster ToT',
+            self._plot_1d_hist(hist=hist, title='Cluster ToT',
                                log_y=False, plot_range=plot_range,
                                x_axis_title=x_axis_title,
                                y_axis_title='# of clusters', suffix='cluster_tot')

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -141,9 +141,9 @@ class Plotting(object):
 
         try:
             conversion_factors = au.ConfigDict(root.configuration_in.bench.calibration['electron_conversion'])
-            if self.scan_config['start_column'] and self.scan_config['stop']  in range(0, 448):  # TODO: Get rid of hardcoded values.
+            if self.scan_config['start_column'] and self.scan_config['stop'] in range(0, 448):  # TODO: Get rid of hardcoded values.
                 self.electron_conversion = conversion_factors['DC_coupled']
-            elif self.scan_config['start_column'] and self.scan_config['stop']  in range(448, 512):
+            elif self.scan_config['start_column'] and self.scan_config['stop'] in range(448, 512):
                 self.electron_conversion = conversion_factors['AC_coupled']
             else:
                 self.log.warning('Both DC and AC coupled pixels enabled. Choose ambiguous electron conversion factor of DC falvors!')

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -136,13 +136,18 @@ class Plotting(object):
             self.HistClusterShape = root.HistClusterShape[:]
             self.HistClusterTot = root.HistClusterTot[:]
             self.clustered = True
+        except tb.NoSuchNodeError:
+            pass
+
+        try:
             conversion_factors = au.ConfigDict(root.configuration_in.bench.calibration['electron_conversion'])
             if self.scan_config['start_column'] in range(0, 448):  # TODO: Get rid of hardcoded values.
                 self.electron_conversion = conversion_factors['DC_coupled']
             else:
                 self.electron_conversion = conversion_factors['AC_coupled']
+            self.electron_axis = True
         except tb.NoSuchNodeError:
-            pass
+            self.electron_axis = False
 
         try:
             in_file.close()
@@ -267,7 +272,7 @@ class Plotting(object):
                 scan_parameter_range = self.scan_parameter_range
             else:
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = True
+                electron_axis = self.electron_axis
                 scan_parameter_range = self.scan_parameter_range
 
             params = [{'scurves': self.HistOcc[:].ravel().reshape((self.rows * self.cols, -1)).T,
@@ -295,7 +300,7 @@ class Plotting(object):
             else:
                 plot_range = self.scan_parameter_range
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = True
+                electron_axis = self.electron_axis
 
             self._plot_distribution(self.ThresholdMap[self.Chi2Sel].T,
                                     plot_range=plot_range,
@@ -319,7 +324,7 @@ class Plotting(object):
                 electron_axis = False
             else:
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = True
+                electron_axis = self.electron_axis
 
             self._plot_stacked_threshold(data=self.ThresholdMap[self.Chi2Sel].T,
                                          tdac_mask=self.tdac_mask[self.Chi2Sel].T,
@@ -348,7 +353,7 @@ class Plotting(object):
                 z_min = 0
                 z_max = 16
             else:
-                electron_axis = True
+                electron_axis = self.electron_axis
                 use_electron_offset = False
                 z_label = 'Threshold'
                 title = 'Threshold'
@@ -376,7 +381,7 @@ class Plotting(object):
             plot_range = None
             if self.run_config['scan_id'] in ['threshold_scan', 'fast_threshold_scan', 'in_time_threshold_scan', 'autorange_threshold_scan', 'crosstalk_scan']:
                 scan_parameter_name = '$\\Delta$ VCAL'
-                electron_axis = True
+                electron_axis = self.electron_axis
             elif self.run_config['scan_id'] == 'global_threshold_tuning':
                 scan_parameter_name = self.scan_config['VTH_name']
                 electron_axis = False
@@ -404,7 +409,7 @@ class Plotting(object):
             mask[~sel] = True
             z_label = 'Noise'
             title = 'Noise'
-            electron_axis = True
+            electron_axis = self.electron_axis
 
             if self.run_config['scan_id'] == 'injection_delay_scan':
                 z_label = 'Finedelay [LSB]'

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -148,9 +148,9 @@ class Plotting(object):
             else:
                 self.log.warning('Both DC and AC coupled pixels enabled. Choose ambiguous electron conversion factor of DC falvors!')
                 self.electron_conversion = conversion_factors['DC_coupled']
-            self.electron_axis = True
+            self.plot_electron_axis = True
         except tb.NoSuchNodeError:
-            self.electron_axis = False
+            self.plot_electron_axis = False
 
         try:
             in_file.close()
@@ -267,19 +267,20 @@ class Plotting(object):
         try:
             if self.run_config['scan_id'] == 'injection_delay_scan':
                 scan_parameter_name = 'Finedelay [LSB]'
-                self.electron_axis = False
+                plot_electron_axis = False
                 scan_parameter_range = range(0, 16)
             elif self.run_config['scan_id'] == 'global_threshold_tuning':
                 scan_parameter_name = self.scan_config['VTH_name']
-                self.electron_axis = False
+                plot_electron_axis = False
                 scan_parameter_range = self.scan_parameter_range
             else:
                 scan_parameter_name = '$\\Delta$ VCAL'
                 scan_parameter_range = self.scan_parameter_range
+                plot_electron_axis = self.plot_electron_axis
 
             params = [{'scurves': self.HistOcc[:].ravel().reshape((self.rows * self.cols, -1)).T,
                        'scan_parameters': scan_parameter_range,
-                       'electron_axis': self.electron_axis,
+                       'electron_axis': plot_electron_axis,
                        'scan_parameter_name': scan_parameter_name}]
 
             for param in params:
@@ -292,20 +293,21 @@ class Plotting(object):
             title = 'Threshold distribution for enabled pixels'
             if self.run_config['scan_id'] == 'injection_delay_scan':
                 scan_parameter_name = 'Finedelay [LSB]'
-                self.electron_axis = False
+                plot_electron_axis = False
                 plot_range = range(0, 16)
                 title = 'Fine delay distribution for enabled pixels'
             elif self.run_config['scan_id'] == 'global_threshold_tuning':
                 plot_range = self.scan_parameter_range
                 scan_parameter_name = self.scan_config['VTH_name']
-                self.electron_axis = False
+                plot_electron_axis = False
             else:
                 plot_range = self.scan_parameter_range
                 scan_parameter_name = '$\\Delta$ VCAL'
+                plot_electron_axis = self.plot_electron_axis
 
             self._plot_distribution(self.ThresholdMap[self.Chi2Sel].T,
                                     plot_range=plot_range,
-                                    electron_axis=self.electron_axis,
+                                    electron_axis=plot_electron_axis,
                                     x_axis_title=scan_parameter_name,
                                     title=title,
                                     log_y=logscale,
@@ -322,14 +324,15 @@ class Plotting(object):
             plot_range = self.scan_parameter_range
             if self.run_config['scan_id'] == 'global_threshold_tuning':
                 scan_parameter_name = self.scan_config['VTH_name']
-                self.electron_axis = False
+                plot_electron_axis = False
             else:
                 scan_parameter_name = '$\\Delta$ VCAL'
+                plot_electron_axis = self.plot_electron_axis
 
             self._plot_stacked_threshold(data=self.ThresholdMap[self.Chi2Sel].T,
                                          tdac_mask=self.tdac_mask[self.Chi2Sel].T,
                                          plot_range=plot_range,
-                                         electron_axis=self.electron_axis,
+                                         electron_axis=plot_electron_axis,
                                          x_axis_title=scan_parameter_name,
                                          y_axis_title='# of pixels',
                                          title='Threshold distribution for enabled pixels',
@@ -346,13 +349,14 @@ class Plotting(object):
             sel = self.Chi2Map[:] > 0.  # Mask not converged fits (chi2 = 0)
             mask[~sel] = True
             if self.run_config['scan_id'] == 'injection_delay_scan':
-                self.electron_axis = False
+                plot_electron_axis = False
                 use_electron_offset = False
                 z_label = 'Finedelay [LSB]'
                 title = 'Injection Delay'
                 z_min = 0
                 z_max = 16
             else:
+                plot_electron_axis = self.plot_electron_axis
                 use_electron_offset = False
                 z_label = 'Threshold'
                 title = 'Threshold'
@@ -360,7 +364,7 @@ class Plotting(object):
                 z_max = None
 
             self._plot_occupancy(hist=np.ma.masked_array(self.ThresholdMap, mask).T,
-                                 electron_axis=self.electron_axis,
+                                 electron_axis=plot_electron_axis,
                                  z_label=z_label,
                                  title=title,
                                  use_electron_offset=use_electron_offset,
@@ -380,17 +384,18 @@ class Plotting(object):
             plot_range = None
             if self.run_config['scan_id'] in ['threshold_scan', 'fast_threshold_scan', 'in_time_threshold_scan', 'autorange_threshold_scan', 'crosstalk_scan']:
                 scan_parameter_name = '$\\Delta$ VCAL'
+                plot_electron_axis = self.plot_electron_axis
             elif self.run_config['scan_id'] == 'global_threshold_tuning':
                 scan_parameter_name = self.scan_config['VTH_name']
-                self.electron_axis = False
+                plot_electron_axis = False
             elif self.run_config['scan_id'] == 'injection_delay_scan':
-                self.electron_axis = False
                 scan_parameter_name = 'Finedelay [LSB]'
+                plot_electron_axis = False
 
             self._plot_distribution(np.ma.masked_array(self.NoiseMap, mask).T,
                                     title='Noise distribution for enabled pixels',
                                     plot_range=plot_range,
-                                    electron_axis=self.electron_axis,
+                                    electron_axis=plot_electron_axis,
                                     use_electron_offset=False,
                                     x_axis_title=scan_parameter_name,
                                     y_axis_title='# of pixels',
@@ -407,13 +412,14 @@ class Plotting(object):
             mask[~sel] = True
             z_label = 'Noise'
             title = 'Noise'
+            plot_electron_axis = self.plot_electron_axis
 
             if self.run_config['scan_id'] == 'injection_delay_scan':
                 z_label = 'Finedelay [LSB]'
                 title = 'Injection Delay Noise'
-                self.electron_axis = False
+                plot_electron_axis = False
             self._plot_occupancy(hist=np.ma.masked_array(self.NoiseMap, mask).T,
-                                 electron_axis=self.electron_axis,
+                                 electron_axis=plot_electron_axis,
                                  use_electron_offset=False,
                                  z_label=z_label,
                                  z_max='median',

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -141,9 +141,9 @@ class Plotting(object):
 
         try:
             conversion_factors = au.ConfigDict(root.configuration_in.bench.calibration['electron_conversion'])
-            if self.scan_config['start_column'] and self.scan_config['stop'] in range(0, 448):  # TODO: Get rid of hardcoded values.
+            if self.scan_config['start_column'] in range(0, 448) and self.scan_config['stop_column'] in range(0, 448):  # TODO: Get rid of hardcoded values.
                 self.electron_conversion = conversion_factors['DC_coupled']
-            elif self.scan_config['start_column'] and self.scan_config['stop'] in range(448, 512):
+            elif self.scan_config['start_column'] in range(448, 512) and self.scan_config['stop_column'] in range(448, 512):
                 self.electron_conversion = conversion_factors['AC_coupled']
             else:
                 self.log.warning('Both DC and AC coupled pixels enabled. Choose ambiguous electron conversion factor of DC falvors!')

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -487,12 +487,11 @@ class Plotting(object):
             tot_calib_file = self.configuration['scan'].get('tot_calib_file', None)
             if tot_calib_file is not None:
                 x_axis_title = 'Cluster Charge [e⁻]'
-                hist = self.HistClusterTot[:] * self.electron_conversion
+                plot_range = plot_range * self.electron_conversion
             else:
                 x_axis_title = 'Cluster ToT [25 ns]'
-                hist = self.HistClusterTot[:]
 
-            self._plot_1d_hist(hist=hist, title='Cluster ToT',
+            self._plot_1d_hist(hist=self.HistClusterTot[:], title='Cluster ToT',
                                log_y=False, plot_range=plot_range,
                                x_axis_title=x_axis_title,
                                y_axis_title='# of clusters', suffix='cluster_tot')

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -479,9 +479,15 @@ class Plotting(object):
             else:
                 plot_range = range(0, np.max(np.nonzero(self.HistClusterTot)))
 
+            tot_calib_file = self.configuration['scan'].get('tot_calib_file', None)
+            if tot_calib_file is not None:
+                x_axis_title = 'Electrons [e⁻]'
+            else:
+                x_axis_title = 'Cluster ToT [25 ns]'
+
             self._plot_1d_hist(hist=self.HistClusterTot[:], title='Cluster ToT',
                                log_y=False, plot_range=plot_range,
-                               x_axis_title='Cluster ToT [25 ns]',
+                               x_axis_title=x_axis_title,
                                y_axis_title='# of clusters', suffix='cluster_tot')
         except Exception:
             self.log.error('Could not create cluster TOT plot!')

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -131,7 +131,7 @@ class Plotting(object):
             self.log.warning('Disabled {} noisy pixels in total.'.format(len(noisy_pixels[0])))
 
         try:
-            _ = root.Cluster[:]  # FIXME: This line of code does not take chunking into account
+            _ = root.Cluster  # FIXME: This line of code does not take chunking into account
             self.HistClusterSize = root.HistClusterSize[:]
             self.HistClusterShape = root.HistClusterShape[:]
             self.HistClusterTot = root.HistClusterTot[:]

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -115,7 +115,7 @@ class Plotting(object):
             self.HistTdcStatus = None
         self.HistOcc = root.HistOcc[:]
         self.HistTot = root.HistTot[:]
-        if self.run_config['scan_id'] in ['threshold_scan', 'fast_threshold_scan', 'global_threshold_tuning', 'in_time_threshold_scan', 'autorange_threshold_scan', 'crosstalk_scan']:
+        if self.run_config['scan_id'] in ['threshold_scan', 'calibrate_tot', 'fast_threshold_scan', 'global_threshold_tuning', 'in_time_threshold_scan', 'autorange_threshold_scan', 'crosstalk_scan']:
             self.ThresholdMap = root.ThresholdMap[:, :]
             self.Chi2Map = root.Chi2Map[:, :]
             self.Chi2Sel = (self.Chi2Map > 0) & (self.Chi2Map < SCURVE_CHI2_UPPER_LIMIT) & (~self.enable_mask)
@@ -166,12 +166,12 @@ class Plotting(object):
             self.create_occupancy_map()
             if self.run_config['scan_id'] in ['simple_scan']:
                 self.create_fancy_occupancy()
-            if self.run_config['scan_id'] in ['analog_scan', 'threshold_scan', 'global_threshold_tuning', 'simple_scan']:
+            if self.run_config['scan_id'] in ['analog_scan', 'threshold_scan', 'global_threshold_tuning', 'simple_scan', 'calibrate_tot']:
                 self.create_hit_pix_plot()
                 self.create_tdac_plot()
                 self.create_tdac_map()
                 self.create_tot_plot()
-            if self.run_config['scan_id'] in ['threshold_scan']:
+            if self.run_config['scan_id'] in ['threshold_scan', 'calibrate_tot']:
                 self.create_tot_hist()
                 self.create_scurves_plot()
                 self.create_threshold_plot()

--- a/tjmonopix2/scans/calibrate_tot.py
+++ b/tjmonopix2/scans/calibrate_tot.py
@@ -1,0 +1,87 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+import numpy as np
+import tables as tb
+
+from numba import njit
+
+from tjmonopix2.analysis import analysis_utils as au
+from tjmonopix2.analysis import analysis, plotting
+from tjmonopix2.scans.scan_threshold import ThresholdScan
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 32,
+    'start_row': 0,
+    'stop_row': 512,
+
+    'n_injections': 100,
+    'VCAL_HIGH': 145,
+    'VCAL_LOW_start': 130,
+    'VCAL_LOW_stop': 0,
+    'VCAL_LOW_step': -1,
+}
+
+
+@njit
+def _calc_mean_avg(array, weights):
+    return np.sum(array * weights) / np.sum(weights)
+
+
+@njit
+def _create_tot_avg(array):
+    original_shape = array.shape
+    array = array.reshape((original_shape[0] * original_shape[1], original_shape[2], original_shape[3]))
+    tot_avg = np.zeros((array.shape[0], array.shape[1]))
+
+    # loop through all pixels
+    for pixel in range(array.shape[0]):
+        for idx in range(array.shape[1]):
+            if array[pixel, idx].any() != 0:
+                tot_avg[pixel, idx] = _calc_mean_avg(np.arange(0, 128, 1), array[pixel, idx])
+
+    return np.reshape(tot_avg, (original_shape[0], original_shape[1], original_shape[2]))
+
+
+class CalibrateToT(ThresholdScan):
+    scan_id = 'calibrate_tot'
+
+    def _analyze(self):
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+
+        self.log.info("Calibrating ToT...")
+
+        analyzed_data_file = self.output_filename + '_interpreted.h5'
+        with tb.open_file(analyzed_data_file, 'r') as in_file:
+            HistTot = in_file.root.HistTot[:, :]
+            scan_params = in_file.root.configuration_in.scan.scan_params[:]
+
+        scan_parameter_range = np.array(scan_params['vcal_high'] - scan_params['vcal_low'], dtype=float)
+        tot_avg = _create_tot_avg(HistTot)
+        inj_tot_cal = au.fit_tot_inj_multithread(tot_avg=tot_avg.reshape(512 * 512, -1), scan_params=scan_parameter_range)
+
+        self.log.success("{0} pixels with successful ToT calibration".format(int(np.count_nonzero(inj_tot_cal[:, :]) / 4)))
+
+        with tb.open_file(analyzed_data_file, 'r+') as out_file:
+            out_file.create_carray(out_file.root,
+                                   name='InjTotCalibration',
+                                   title='Injection Tot Calibration Fit',
+                                   obj=inj_tot_cal,
+                                   filters=tb.Filters(complib='blosc',
+                                                      complevel=5,
+                                                      fletcher32=False))
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+
+if __name__ == "__main__":
+    with CalibrateToT(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/tjmonopix2/scans/scan_simple.py
+++ b/tjmonopix2/scans/scan_simple.py
@@ -20,6 +20,8 @@ scan_configuration = {
 
     'scan_timeout': False,    # Timeout for scan after which the scan will be stopped, in seconds; if False no limit on scan time
     'max_triggers': 1000000,  # Number of maximum received triggers after stopping readout, if False no limit on received trigger
+
+    'tot_calib_file': None    # path to ToT calibration file for charge to e⁻ conversion, if None no conversion will be done
 }
 
 
@@ -89,7 +91,11 @@ class SimpleScan(ScanBase):
         self.log.success('Scan finished')
 
     def _analyze(self):
-        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+        tot_calib_file = self.configuration['scan'].get('tot_calib_file', None)
+        if tot_calib_file is not None:
+            self.configuration['bench']['analysis']['cluster_hits'] = True
+
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', tot_calib_file=tot_calib_file, **self.configuration['bench']['analysis']) as a:
             a.analyze_data()
 
         if self.configuration['bench']['analysis']['create_pdf']:

--- a/tjmonopix2/testbench.yaml
+++ b/tjmonopix2/testbench.yaml
@@ -50,7 +50,7 @@ analysis:
   create_pdf: True # Create analysis summary pdf
   # module_plotting: True  # Create combined plots for chip in a module
   store_hits: True # store hit table
-  # cluster_hits: False # store cluster data
+  cluster_hits: False # store cluster data
   # analyze_tdc: False # analyze TDC words
   # use_tdc_trigger_dist: False # analyze TDC to TRG distance
   # align_method: 0 # how to detect new events

--- a/tjmonopix2/testbench.yaml
+++ b/tjmonopix2/testbench.yaml
@@ -37,6 +37,9 @@ hardware: # Setup-specific hardware settings
   enable_NTC: False # Only enable if you know you have the correct resistors mounted on the BDAQ board!
 
 calibration: # Setup-specific calibration constants
+  electron_conversion: # Charge conversion from DAC to e⁻, typically 8.8 for DC and 13.3 for AC (slightly chip dependent!)
+    DC_coupled: 8.8
+    AC_coupled: 13.3
   bdaq_ntc: # Resistors on BDAQ board for NTC readout
     R16: 412.00e3
     R17: 13.00e3


### PR DESCRIPTION
This PR enables per pixel ToT calibration. A scan routine analogue to a threshold scan as basis for the calibration is added. Analyzing scripts converting a measured ToT spectrum (source/beam spectrum) w.r.t. a calibration file are added. Fixes Issue #29.