### PR TITLE
WIP: Add a dedicated external trigger scan

### DIFF
--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -177,7 +177,7 @@ class Plotting(object):
         else:
             self.create_parameter_page()
             self.create_occupancy_map()
-            if self.run_config['scan_id'] in ['source_scan','ext_trigger_scan']:
+            if self.run_config['scan_id'] in ['source_scan', 'ext_trigger_scan']:
                 self.create_fancy_occupancy()
             if self.run_config['scan_id'] in ['analog_scan', 'threshold_scan', 'global_threshold_tuning', 'source_scan', 'ext_trigger_scan', 'calibrate_tot']:
                 self.create_hit_pix_plot()

--- a/tjmonopix2/analysis/plotting.py
+++ b/tjmonopix2/analysis/plotting.py
@@ -177,9 +177,9 @@ class Plotting(object):
         else:
             self.create_parameter_page()
             self.create_occupancy_map()
-            if self.run_config['scan_id'] in ['simple_scan']:
+            if self.run_config['scan_id'] in ['source_scan','ext_trigger_scan']:
                 self.create_fancy_occupancy()
-            if self.run_config['scan_id'] in ['analog_scan', 'threshold_scan', 'global_threshold_tuning', 'simple_scan', 'calibrate_tot']:
+            if self.run_config['scan_id'] in ['analog_scan', 'threshold_scan', 'global_threshold_tuning', 'source_scan', 'ext_trigger_scan', 'calibrate_tot']:
                 self.create_hit_pix_plot()
                 self.create_tdac_plot()
                 self.create_tdac_map()

--- a/tjmonopix2/scans/scan_ext_trigger.py
+++ b/tjmonopix2/scans/scan_ext_trigger.py
@@ -18,6 +18,7 @@ scan_configuration = {
     'start_row': 0,
     'stop_row': 512,
 
+    'scan_timeout': False,    # Timeout for scan after which the scan will be stopped, in seconds; if False no limit on scan time
     'max_triggers': 1000000,  # Number of maximum received triggers after stopping readout, if False no limit on received trigger
 
     'tot_calib_file': None    # path to ToT calibration file for charge to e⁻ conversion, if None no conversion will be done
@@ -29,31 +30,51 @@ class ExtTriggerScan(ScanBase):
 
     stop_scan = threading.Event()
 
-    def _configure(self, max_triggers=1000, start_column=0, stop_column=512, start_row=0, stop_row=512, **_):
+    def _configure(self, scan_timeout=False, max_triggers=1000, start_column=0, stop_column=512, start_row=0, stop_row=512, **_):
         self.log.info('External trigger scan needs TLU running!')
+
+        if scan_timeout and max_triggers:
+            self.log.warning('You should only use one of the stop conditions at a time.')
 
         self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
         self.chip.masks.apply_disable_mask()
         self.chip.masks.update()
 
         self.daq.configure_tlu_veto_pulse(veto_length=500)
-        self.daq.configure_tlu_module(max_triggers=max_triggers)
+        if max_triggers:
+            self.daq.configure_tlu_module(max_triggers=max_triggers)
 
-    def _scan(self, max_triggers=1000, **_):
-        self.pbar = tqdm(total=max_triggers, unit=' Triggers')
+    def _scan(self, scan_timeout=False, max_triggers=1000, **_):
+        def timed_out():
+            if scan_timeout:
+                current_time = time.time()
+                if current_time - start_time > scan_timeout:
+                    self.log.info('Scan timeout was reached')
+                    return True
+            return False
+
+        if scan_timeout:
+            self.pbar = tqdm(total=scan_timeout, unit='')  # [s]
+        elif max_triggers:
+            self.pbar = tqdm(total=max_triggers, unit=' Triggers')
+        start_time = time.time()
 
         with self.readout():
             self.stop_scan.clear()
             self.daq.enable_tlu_module()
 
-            while not self.stop_scan.is_set():
+            while not (self.stop_scan.is_set() or timed_out()):
                 try:
-                    triggers = self.daq.get_trigger_counter()
+                    if max_triggers:
+                        triggers = self.daq.get_trigger_counter()
                     time.sleep(1)
 
                     # Update progress bar
                     try:
-                        self.pbar.update(self.daq.get_trigger_counter() - triggers)
+                        if scan_timeout:
+                            self.pbar.update(1)
+                        elif max_triggers:
+                            self.pbar.update(self.daq.get_trigger_counter() - triggers)
                     except ValueError:
                         pass
 

--- a/tjmonopix2/scans/scan_ext_trigger.py
+++ b/tjmonopix2/scans/scan_ext_trigger.py
@@ -1,0 +1,88 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+import time
+import threading
+from tqdm import tqdm
+
+from tjmonopix2.analysis import analysis, plotting
+from tjmonopix2.system.scan_base import ScanBase
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 224,
+    'start_row': 0,
+    'stop_row': 512,
+
+    'max_triggers': 1000000,  # Number of maximum received triggers after stopping readout, if False no limit on received trigger
+
+    'tot_calib_file': None    # path to ToT calibration file for charge to e⁻ conversion, if None no conversion will be done
+}
+
+
+class ExtTriggerScan(ScanBase):
+    scan_id = 'ext_trigger_scan'
+
+    stop_scan = threading.Event()
+
+    def _configure(self, max_triggers=1000, start_column=0, stop_column=512, start_row=0, stop_row=512, **_):
+        self.log.info('External trigger scan needs TLU running!')
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks.apply_disable_mask()
+        self.chip.masks.update()
+
+        self.daq.configure_tlu_veto_pulse(veto_length=500)
+        self.daq.configure_tlu_module(max_triggers=max_triggers)
+
+    def _scan(self, max_triggers=1000, **_):
+        self.pbar = tqdm(total=max_triggers, unit=' Triggers')
+
+        with self.readout():
+            self.stop_scan.clear()
+            self.daq.enable_tlu_module()
+
+            while not self.stop_scan.is_set():
+                try:
+                    triggers = self.daq.get_trigger_counter()
+                    time.sleep(1)
+
+                    # Update progress bar
+                    try:
+                        self.pbar.update(self.daq.get_trigger_counter() - triggers)
+                    except ValueError:
+                        pass
+
+                    # Stop scan if reached trigger limit
+                    if max_triggers and triggers >= max_triggers:
+                        self.stop_scan.set()
+                        self.log.info('Trigger limit was reached: {0}'.format(max_triggers))
+
+                except KeyboardInterrupt:  # React on keyboard interupt
+                    self.stop_scan.set()
+                    self.log.info('Scan was stopped due to keyboard interrupt')
+
+        self.pbar.close()
+        self.daq.disable_tlu_module()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        tot_calib_file = self.configuration['scan'].get('tot_calib_file', None)
+        if tot_calib_file is not None:
+            self.configuration['bench']['analysis']['cluster_hits'] = True
+
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', tot_calib_file=tot_calib_file, **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+
+if __name__ == "__main__":
+    with ExtTriggerScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/tjmonopix2/scans/scan_source.py
+++ b/tjmonopix2/scans/scan_source.py
@@ -18,30 +18,23 @@ scan_configuration = {
     'start_row': 0,
     'stop_row': 512,
 
-    'scan_timeout': False,    # Timeout for scan after which the scan will be stopped, in seconds; if False no limit on scan time
-    'max_triggers': 1000000,  # Number of maximum received triggers after stopping readout, if False no limit on received trigger
+    'scan_timeout': 30,    # Timeout for scan after which the scan will be stopped, in seconds; if False no limit on scan time
 
     'tot_calib_file': None    # path to ToT calibration file for charge to e⁻ conversion, if None no conversion will be done
 }
 
 
-class SimpleScan(ScanBase):
-    scan_id = 'simple_scan'
+class SourceScan(ScanBase):
+    scan_id = 'source_scan'
 
     stop_scan = threading.Event()
 
-    def _configure(self, scan_timeout=10, max_triggers=False, start_column=0, stop_column=512, start_row=0, stop_row=512, **_):
-        if scan_timeout and max_triggers:
-            self.log.warning('You should only use one of the stop conditions at a time.')
-
+    def _configure(self, start_column=0, stop_column=512, start_row=0, stop_row=512, **_):
         self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
         self.chip.masks.apply_disable_mask()
         self.chip.masks.update()
 
-        self.daq.configure_tlu_veto_pulse(veto_length=500)
-        self.daq.configure_tlu_module(max_triggers=max_triggers)
-
-    def _scan(self, scan_timeout=10, max_triggers=False, **_):
+    def _scan(self, scan_timeout=10, **_):
         def timed_out():
             if scan_timeout:
                 current_time = time.time()
@@ -50,44 +43,27 @@ class SimpleScan(ScanBase):
                     return True
             return False
 
-        if scan_timeout:
-            self.pbar = tqdm(total=scan_timeout, unit='')  # [s]
-        elif max_triggers:
-            self.pbar = tqdm(total=max_triggers, unit=' Triggers')
+        self.pbar = tqdm(total=scan_timeout, unit='')  # [s]
         start_time = time.time()
 
         with self.readout():
             self.stop_scan.clear()
-            self.daq.enable_tlu_module()
 
             while not (self.stop_scan.is_set() or timed_out()):
                 try:
-                    if max_triggers:
-                        triggers = self.daq.get_trigger_counter()
                     time.sleep(1)
 
                     # Update progress bar
                     try:
-                        if scan_timeout:
-                            self.pbar.update(1)
-                        elif max_triggers:
-                            self.pbar.update(self.daq.get_trigger_counter() - triggers)
+                        self.pbar.update(1)
                     except ValueError:
                         pass
-
-                    # Stop scan if reached trigger limit
-                    if max_triggers and triggers >= max_triggers:
-                        self.stop_scan.set()
-                        self.log.info('Trigger limit was reached: {0}'.format(max_triggers))
 
                 except KeyboardInterrupt:  # React on keyboard interupt
                     self.stop_scan.set()
                     self.log.info('Scan was stopped due to keyboard interrupt')
 
         self.pbar.close()
-        if max_triggers:
-            self.daq.disable_tlu_module()
-
         self.log.success('Scan finished')
 
     def _analyze(self):
@@ -104,5 +80,5 @@ class SimpleScan(ScanBase):
 
 
 if __name__ == "__main__":
-    with SimpleScan(scan_config=scan_configuration) as scan:
+    with SourceScan(scan_config=scan_configuration) as scan:
         scan.start()


### PR DESCRIPTION
This PR introduces a dedicated external trigger scan (`scan_ext_trigger`) for measurements utilizing a TLU. Additionally, the old `scan_simple.py` is changed to `scan_source.py` and will not support TLU based measurements further.
This way we want to separate between source measurements and beam test measurements with a TLU setup to avoid confusion in the scan naming and calling.