### PR TITLE
Removed +1 in charge calculation

### DIFF
--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -265,7 +265,7 @@ class Analysis(object):
                 hit_dtype=hit_dtype,
                 cluster_fields=cluster_fields,
                 cluster_dtype=self.cluster_dtype,
-                min_hit_charge=1,
+                min_hit_charge=0,
                 max_hit_charge=max_hit_charge,
                 column_cluster_distance=5,
                 row_cluster_distance=5,
@@ -343,7 +343,7 @@ class Analysis(object):
                             event_table.flush()
                         else:
                             self.log.error("No TLU data found in raw data. Check data or disable event building")
-                            raise Exception
+                            # raise Exception
                     if self.cluster_hits:
                         if self.build_events:
                             data_to_clusterizer = event_dat
@@ -355,7 +355,7 @@ class Analysis(object):
                             hit_data_cs_fmt['frame'][:] = -1
                             hit_data_cs_fmt['column'][:] = hit_dat['col'][:]
                             hit_data_cs_fmt['row'][:] = hit_dat['row'][:]
-                            hit_data_cs_fmt['charge'][:] = ((hit_dat[:]["te"] - hit_dat[:]["le"]) & 0x7F) + 1
+                            hit_data_cs_fmt['charge'][:] = ((hit_dat[:]["te"] - hit_dat[:]["le"]) & 0x7F)
                             hit_data_cs_fmt['timestamp'][:] = hit_dat['timestamp'][:]
                             data_to_clusterizer = hit_data_cs_fmt
 

--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -343,7 +343,7 @@ class Analysis(object):
                             event_table.flush()
                         else:
                             self.log.error("No TLU data found in raw data. Check data or disable event building")
-                            # raise Exception
+                            raise Exception
                     if self.cluster_hits:
                         if self.build_events:
                             data_to_clusterizer = event_dat

--- a/tjmonopix2/analysis/events.py
+++ b/tjmonopix2/analysis/events.py
@@ -43,7 +43,7 @@ def build_events(hits, buffer, trigger_n=0, trigger_ts=0, event_n=0):
                 buffer[event_i]['trigger_number'] = trigger_n
                 buffer[event_i]['column'] = hits[hit_i]["col"] + 1
                 buffer[event_i]['row'] = hits[hit_i]["row"] + 1
-                buffer[event_i]['charge'] = ((hits[hit_i]["te"] - hits[hit_i]["le"]) & 0x7F) + 1
+                buffer[event_i]['charge'] = ((hits[hit_i]["te"] - hits[hit_i]["le"]) & 0x7F)
                 buffer[event_i]['timestamp'] = hits[hit_i]["timestamp"]
                 event_i += 1
         hit_i += 1


### PR DESCRIPTION
Initially the charge was calculated by adding one to the difference of the leading and the trailing edge.
This offset is not needed and leads to inconsistencies between different analysis procedures. 

I checked the clustering again by interpreting some old beam data and could not find any issues with this change.