### PR TITLE
Event building in EUDET mode

### DIFF
--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -342,7 +342,7 @@ class Analysis(object):
                             event_table.append(event_dat)
                             event_table.flush()
                         else:
-                            self.log.warning("No TLU data found in raw data. Check data or disable event building")
+                            self.log.warning("No TLU data found in raw data chunk.")
                             continue
                     if self.cluster_hits:
                         if self.build_events:

--- a/tjmonopix2/analysis/analysis.py
+++ b/tjmonopix2/analysis/analysis.py
@@ -313,7 +313,7 @@ class Analysis(object):
                     if self.tot_calib_file:
                         cs_tot_size = 2048
                     else:
-                        cs_tot_size = 256
+                        cs_tot_size = 512
                     hist_cs_size = np.zeros(shape=(30, ), dtype=np.uint32)
                     hist_cs_tot = np.zeros(shape=(cs_tot_size, ), dtype=np.uint32)
                     hist_cs_shape = np.zeros(shape=(300, ), dtype=np.int32)
@@ -342,8 +342,8 @@ class Analysis(object):
                             event_table.append(event_dat)
                             event_table.flush()
                         else:
-                            self.log.error("No TLU data found in raw data. Check data or disable event building")
-                            raise Exception
+                            self.log.warning("No TLU data found in raw data. Check data or disable event building")
+                            continue
                     if self.cluster_hits:
                         if self.build_events:
                             data_to_clusterizer = event_dat


### PR DESCRIPTION
Changed the event building analysis in EUDET mode to work by default.
These changes were already implemented locally at our branches, so we can also push them.

Changed the no TLU data found exception to a warning and used a `continue` at this point.
Also increased the `cs_tot_size` to 512.

Fixes [#40](https://github.com/SiLab-Bonn/tj-monopix2-daq/issues/40)