### PR TITLE
Fix: revert deleted readout controller config

### DIFF
--- a/tjmonopix2/system/tjmonopix2.py
+++ b/tjmonopix2/system/tjmonopix2.py
@@ -694,6 +694,7 @@ class TJMonoPix2():
         if not self.daq.communication_established:
             self.init_communication()
         self.reset()
+        self.configure_rx()
 
         if self.daq.board_version == 'mio3':
             self.log.info(str(self.get_power_status()))


### PR DESCRIPTION
The configuration of the column-drain readout controller was accidentally deleted at some point and causes quite some troubles. This PR reverts it.