### PR TITLE
Simplify trigger mode selection

### DIFF
--- a/tjmonopix2/scans/scan_ext_trigger.py
+++ b/tjmonopix2/scans/scan_ext_trigger.py
@@ -19,6 +19,7 @@ scan_configuration = {
     'stop_row': 512,
 
     'scan_timeout': False,    # Timeout for scan after which the scan will be stopped, in seconds; if False no limit on scan time
+    'trigger_mode': 'eudet',
     'max_triggers': 1000000,  # Number of maximum received triggers after stopping readout, if False no limit on received trigger
 
     'tot_calib_file': None    # path to ToT calibration file for charge to e⁻ conversion, if None no conversion will be done
@@ -30,7 +31,7 @@ class ExtTriggerScan(ScanBase):
 
     stop_scan = threading.Event()
 
-    def _configure(self, scan_timeout=False, max_triggers=1000, start_column=0, stop_column=512, start_row=0, stop_row=512, **_):
+    def _configure(self, scan_timeout=False, max_triggers=1000, trigger_mode="eudet", start_column=0, stop_column=512, start_row=0, stop_row=512, **_):
         self.log.info('External trigger scan needs TLU running!')
 
         if scan_timeout and max_triggers:
@@ -42,7 +43,7 @@ class ExtTriggerScan(ScanBase):
 
         self.daq.configure_tlu_veto_pulse(veto_length=500)
         if max_triggers:
-            self.daq.configure_tlu_module(max_triggers=max_triggers)
+            self.daq.configure_tlu_module(max_triggers=max_triggers, trigger_mode=trigger_mode)
 
     def _scan(self, scan_timeout=False, max_triggers=1000, **_):
         def timed_out():

--- a/tjmonopix2/system/bdaq53.py
+++ b/tjmonopix2/system/bdaq53.py
@@ -273,7 +273,7 @@ class BDAQ53(Dut):
     def set_trigger_data_delay(self, trigger_data_delay):
         self['tlu']['TRIGGER_DATA_DELAY'] = trigger_data_delay
 
-    def configure_tlu_module(self, aidamode=False, max_triggers=False):
+    def configure_tlu_module(self, trigger_mode="eudet", max_triggers=False):
         self.log.info('Configuring TLU module...')
         self['tlu']['RESET'] = 1    # Reset first TLU module
         for key, value in self.configuration['TLU'].items():    # Set specified registers
@@ -286,15 +286,17 @@ class BDAQ53(Dut):
             self['tlu']['MAX_TRIGGERS'] = 0  # unlimited number of triggers
 
         # AIDA mode
-        if aidamode:
+        if trigger_mode.lower() == "aida":
             self['tlu']["TRIGGER_MODE"] = 2
             self['tlu']["TRIGGER_LOW_TIMEOUT"] = 4
             self['tlu']["TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES"] = 1
             self['tlu']['EN_TLU_RESET_TIMESTAMP'] = 1
-        else:
+        elif trigger_mode.lower() == "eudet":
             self['tlu']["TRIGGER_MODE"] = 3
             self['tlu']["TRIGGER_LOW_TIMEOUT"] = 0
             self['tlu']["TRIGGER_HANDSHAKE_ACCEPT_WAIT_CYCLES"] = 5
+        else:
+            raise ValueError("Invalid trigger mode selected. Supported options: 'eudet' | 'aida'")
 
     def get_tlu_erros(self):
         return (self['tlu']['TRIGGER_LOW_TIMEOUT_ERROR_COUNTER'], self['tlu']['TLU_TRIGGER_ACCEPT_ERROR_COUNTER'])


### PR DESCRIPTION
Adds a scan parameter to select the trigger mode of the TLU in external trigger scans in preparation of moving it to the `testbench.yaml`. This comes with a sanity check as well.