### PR TITLE
Empty FIFO before resetting

### DIFF
--- a/tjmonopix2/system/fifo_readout.py
+++ b/tjmonopix2/system/fifo_readout.py
@@ -351,13 +351,14 @@ class FifoReadout(object):
     def reset_sram_fifo(self, timeout=1):
         fifo_size = self.daq['FIFO']['FIFO_SIZE']
         self.log.debug('Resetting FIFO: size = %i', fifo_size)
-
+        self.update_timestamp()
+        
         # First drain the FIFO before resetting
         self.log.debug('Draining FIFO before reset...')
         start = time()
         while time() - start < 0.5:  # Try draining for 500ms
             data = self.daq['FIFO'].get_data()
-            if data.shape[0] == 0:
+            if len(data) == 0:
                 break
 
         self.daq.reset_fifo()

--- a/tjmonopix2/system/fifo_readout.py
+++ b/tjmonopix2/system/fifo_readout.py
@@ -348,15 +348,30 @@ class FifoReadout(object):
         t2 = datetime.datetime.fromtimestamp(t1)
         return mktime(t2.timetuple()) + 1e-6 * t2.microsecond
 
-    def reset_sram_fifo(self):
+    def reset_sram_fifo(self, timeout=1):
         fifo_size = self.daq['FIFO']['FIFO_SIZE']
         self.log.debug('Resetting FIFO: size = %i', fifo_size)
-        self.update_timestamp()
-        self.daq['FIFO']['RESET']
-        sleep(0.01)  # sleep here for a while
-        fifo_size = self.daq['FIFO']['FIFO_SIZE']
-        if fifo_size != 0:
-            self.log.warning('FIFO not empty after reset: size = %i', fifo_size)
+
+        # First drain the FIFO before resetting
+        self.log.debug('Draining FIFO before reset...')
+        start = time()
+        while time() - start < 0.5:  # Try draining for 500ms
+            data = self.daq['FIFO'].get_data()
+            if data.shape[0] == 0:
+                break
+
+        self.daq.reset_fifo()
+
+        # Wait for FIFO to be empty
+        start = time()
+        while time() - start < timeout:
+            fifo_size = self.daq['FIFO']['FIFO_SIZE']
+            if fifo_size == 0:
+                self.log.debug('FIFO emptied after reset')
+                return
+            sleep(0.01)
+
+        self.log.warning('FIFO not empty after reset: size = %i', fifo_size)
 
     def reset_rx(self, channels=None):
         self.log.debug('Resetting RX')

--- a/tjmonopix2/system/fifo_readout.py
+++ b/tjmonopix2/system/fifo_readout.py
@@ -351,7 +351,6 @@ class FifoReadout(object):
     def reset_sram_fifo(self, timeout=1):
         fifo_size = self.daq['FIFO']['FIFO_SIZE']
         self.log.debug('Resetting FIFO: size = %i', fifo_size)
-        self.update_timestamp()
         
         # First drain the FIFO before resetting
         self.log.debug('Draining FIFO before reset...')
@@ -371,7 +370,8 @@ class FifoReadout(object):
                 self.log.debug('FIFO emptied after reset')
                 return
             sleep(0.01)
-
+        
+        self.update_timestamp()
         self.log.warning('FIFO not empty after reset: size = %i', fifo_size)
 
     def reset_rx(self, channels=None):


### PR DESCRIPTION
Whilst running scans at the setup in IFIC, I saw 'FIFO not empty after reset...' somewhat frequently. This MR clears adds additional get_data() calls to read data from the FIFO before resetting, to be sure its clear before reset. The post reset logic is similar, but now the MR polls the FIFO size up to timeout (default 1) seconds. With this, I do not see the same 'FIFO not empty after reset' warnings in our setup. The MR also calls daq.reset_fifo() instead of self.daq['FIFO']['RESET'] which is functionally the same but wasn't being used for some reason.